### PR TITLE
fix: allow wasm in mv3 extension pages

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -23,9 +23,10 @@ export default defineBackground({
       },
     );
 
-    // The WASM matcher runs here, not in the content script: the worker's
-    // extension CSP permits `new WebAssembly.Module`, while strict host-page
-    // CSPs (GitHub etc.) block it in the content-script isolated world.
+    // The WASM matcher runs here, not in the content script: host-page CSPs
+    // still block `new WebAssembly.Module` in the content-script isolated
+    // world, and the extension worker must explicitly opt into
+    // `wasm-unsafe-eval` via MV3 `content_security_policy`.
     onMessage('matcherSetWords', ({ data }) => {
       ensureMatcher().setWords(data.active, data.deleted);
     });

--- a/src/core/messaging.ts
+++ b/src/core/messaging.ts
@@ -9,7 +9,8 @@ import type {
 // in the host page's isolated world, which inherits the page CSP. On strict
 // sites (e.g. GitHub) that omit `wasm-unsafe-eval`, `new WebAssembly.Module`
 // throws `CompileError`, so the matcher must be driven over messaging from the
-// worker (whose extension CSP permits WASM).
+// worker. The worker itself also needs MV3 extension CSP to opt into
+// `wasm-unsafe-eval`.
 interface ProtocolMap {
   trans(data: IWordQuery): string;
   // Sync the active/deleted word sets into the background matcher automata.

--- a/src/wasm/README.md
+++ b/src/wasm/README.md
@@ -13,7 +13,9 @@ Frontend glue for the Rust→WASM word matcher (`crates/wasm-matcher`).
 (`entrypoints/background.ts`): a content script lives in the host page's
 isolated world and inherits the page CSP, so on sites without
 `wasm-unsafe-eval` (GitHub, X, …) `new WebAssembly.Module` throws
-`CompileError`. The worker's extension CSP permits WASM. Content scripts reach
-the matcher over messaging through `src/content-scripts/matcherFacade.ts`,
-which parses the wordsList into active/deleted sets and skips re-syncing the
-worker when they are unchanged.
+`CompileError`. The worker must also opt into
+`content_security_policy.extension_pages` with `'wasm-unsafe-eval'`; MV3's
+default `script-src 'self'` is not enough for `initSync`. Content scripts
+reach the matcher over messaging through
+`src/content-scripts/matcherFacade.ts`, which parses the wordsList into
+active/deleted sets and skips re-syncing the worker when they are unchanged.

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -20,6 +20,10 @@ export default defineConfig({
   manifest: {
     description: '记单词的小插件',
     permissions: ['storage'],
+    content_security_policy: {
+      extension_pages:
+        "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",
+    },
     homepage_url:
       'https://github.com/yebei199/meow-memorizing',
   },


### PR DESCRIPTION
## Summary
- add MV3 `content_security_policy.extension_pages` with `wasm-unsafe-eval`
- keep the Rust/WASM matcher in the background worker and fix the related docs/comments
- rebuild and verify the generated manifest contains the expected CSP

## Test Plan
- [x] `bun run compile`
- [x] `bun run build`
- [x] confirm `.output/chrome-mv3/manifest.json` contains `script-src 'self' 'wasm-unsafe-eval'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation clarifying WebAssembly module initialization requirements and Content Security Policy configuration.

* **Chores**
  * Extended security configuration to properly support WebAssembly functionality in the extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->