### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "meow-memorizing",
   "description": "记单词的小插件",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "license": "LGPL-3.0-only",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump extension/package version from `1.0.0` to `1.0.1`
- keep the MV3 WASM CSP fix from #128 as the release base
- verify manifest version and packaged zip name match `1.0.1`

## Test Plan
- [x] `bun run compile`
- [x] `just zip`
- [x] confirm `.output/chrome-mv3/manifest.json` reports `1.0.1`
- [x] confirm output zip is `meow-memorizing-1.0.1-chrome.zip`
