### PR TITLE
fix: refresh wrapped highlights after selecting new words

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "meow-memorizing",
   "description": "记单词的小插件",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "license": "LGPL-3.0-only",
   "scripts": {

--- a/src/content-scripts/domUtils.ts
+++ b/src/content-scripts/domUtils.ts
@@ -1,8 +1,13 @@
-import { createRoot } from 'react-dom/client';
+import { createRoot, type Root } from 'react-dom/client';
 import HighlightedText from '@/src/components/transline/HighlightedText.tsx';
 
 // 用于标记已处理的文本节点
 let processedTextNodes = new WeakSet<Text>();
+const wrappedTextNodes = new Set<{
+  wrapper: HTMLSpanElement;
+  root: Root;
+  text: string;
+}>();
 // Marks a span that wraps one text node's React-managed highlight tree. Its
 // subtree must be skipped on rescans (it is owned by React), but unlike
 // data-meow-ignore it stays selectable so users can still query words inside it.
@@ -129,6 +134,7 @@ export async function processTextNode(
   parent.replaceChild(wrapper, textNode);
 
   const root = createRoot(wrapper);
+  wrappedTextNodes.add({ wrapper, root, text });
   root.render(HighlightedText({ text, matches }));
 }
 
@@ -136,5 +142,17 @@ export async function processTextNode(
  * 重置已处理的文本节点标记（用于强制重新处理）
  */
 export function resetProcessedTextNodes(): void {
+  for (const wrapped of wrappedTextNodes) {
+    const parent = wrapped.wrapper.parentNode;
+    if (!parent) continue;
+
+    wrapped.root.unmount();
+    parent.replaceChild(
+      document.createTextNode(wrapped.text),
+      wrapped.wrapper,
+    );
+  }
+
+  wrappedTextNodes.clear();
   processedTextNodes = new WeakSet<Text>();
 }

--- a/tests/e2e/selection-tooltip.spec.ts
+++ b/tests/e2e/selection-tooltip.spec.ts
@@ -89,6 +89,43 @@ test('selecting a word immediately highlights all existing matches', async ({
   await h.close();
 });
 
+test('selecting a word inside an existing highlight tree immediately highlights it', async ({
+  browser,
+}) => {
+  const h = await setupBundleHarness(browser, {
+    url: 'http://127.0.0.1:5199/sample.html',
+    seedWords: {
+      hello: {
+        word: 'hello',
+        isDeleted: false,
+        queryTimes: 1,
+        deleteTimes: 0,
+      },
+    },
+  });
+
+  await expect(h.page.locator('[data-word="hello"]')).toHaveCount(
+    2,
+    { timeout: 15000 },
+  );
+
+  await selectWord(h.page, 'body', 'world');
+
+  const tooltip = h.page.locator(
+    '[data-meow-tooltip-root="selection"]',
+  );
+  await expect(tooltip).toHaveCount(1, { timeout: 15000 });
+  await expect(tooltip).toBeVisible();
+  await expect(tooltip).toContainText('已加入词库');
+
+  await expect(h.page.locator('[data-word="world"]')).toHaveCount(
+    1,
+    { timeout: 15000 },
+  );
+
+  await h.close();
+});
+
 test('highlights and opens hover cards inside github-like inline links', async ({
   browser,
 }) => {


### PR DESCRIPTION
## Summary
- restore wrapped highlight trees to text before full rescans
- add e2e coverage for selecting a new word inside an existing highlight tree
- bump extension version to 1.0.2

## Verification
- bun run compile
- bun run build
- bunx playwright test tests/e2e/selection-tooltip.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Enhanced internal highlight management and cleanup processes for improved reliability.

* **Tests**
  * Added test coverage for selection behavior with existing highlights.

* **Chores**
  * Patch version bumped to 1.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->