### PR TITLE
chore: release 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "meow-memorizing",
   "description": "记单词的小插件",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "license": "LGPL-3.0-only",
   "scripts": {


### PR DESCRIPTION
Bump package version to 1.0.3 so the master release workflow performs a real release run and publishes Chrome MV3, Firefox, and source ZIP assets.