### PR TITLE
ci: fix release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,8 +129,9 @@ jobs:
         run: |
           if ! git rev-parse "$TAG" >/dev/null 2>&1; then
             git tag "$TAG" "$GITHUB_SHA"
-            git -c http.extraheader="AUTHORIZATION: bearer $GH_TOKEN" \
-              push origin "refs/tags/$TAG"
+            git push \
+              "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+              "refs/tags/$TAG"
           fi
 
           if gh release view "$TAG" >/dev/null 2>&1; then

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "meow-memorizing",
   "description": "记单词的小插件",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "license": "LGPL-3.0-only",
   "scripts": {


### PR DESCRIPTION
Fix tag push authentication when checkout credentials are not persisted, then bump to 1.0.4 to trigger a real release run with Chrome MV3, Firefox, and source ZIP assets.