### PR TITLE
docs: refresh README GIF and align license metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 https://chromewebstore.google.com/detail/ginipindgefglbpiaogadmdknaaojdhp?utm_source=item-share-cb
 # 使用方法如下
 
-![example.gif](https://i.imgur.com/UMXpOQS.gif)
+![example.gif](https://upload.cryptorust.uk/u/67HVap.gif)
 
 ## 打包
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fyebei199%2Fmeow-memorizing.svg?type=small)](https://app.fossa.com/projects/git%2Bgithub.com%2Fyebei199%2Fmeow-memorizing?ref=badge_small)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fyebei199%2Fmeow-memorizing.svg?type=shield&issueType=security)](https://app.fossa.com/projects/git%2Bgithub.com%2Fyebei199%2Fmeow-memorizing?ref=badge_shield&issueType=security)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fyebei199%2Fmeow-memorizing.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fyebei199%2Fmeow-memorizing?ref=badge_shield&issueType=license)
-![License](https://img.shields.io/github/license/pot-app/pot-desktop.svg)
+![License](https://img.shields.io/github/license/yebei199/meow-memorizing.svg)
 
 ![ts](https://img.shields.io/badge/typescript-blue?logo=typescript&logoColor=white)
 ![react](https://img.shields.io/badge/react-blue?logo=react&logoColor=white)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "version": "1.0.4",
   "type": "module",
-  "license": "LGPL-3.0-only",
+  "license": "GPL-3.0-only",
   "scripts": {
     "dev": "wxt",
     "dev:firefox": "wxt -b firefox",


### PR DESCRIPTION
## Summary
- refresh the README demo GIF with the current Playwright-recorded extension flow uploaded to Zipline
- align package license metadata with the repository GPL-3.0-only license
- fix the README license badge to point at this repository

## Validation
- `bun run docs:gif` after installing Playwright ffmpeg
- `curl -I https://upload.cryptorust.uk/u/67HVap.gif`
- `bunx biome ci biome.jsonc package.json scripts/update-readme-gif.ts tests/e2e/bundleHarness.ts`
- pre-commit `bun run build` generated Chrome MV3, Firefox, and source ZIP artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated README documentation with corrected badges and asset references.
  * Changed project license to GPL-3.0-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->