### PR TITLE
ci: release packages only from tags

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,6 +3,7 @@
 GitHub Actions entry points for repository automation.
 
 - `ci.yml` - validates pull requests and `master` pushes with Bun, TypeScript,
-  Biome, Rust checks, extension builds, and Playwright e2e tests.
-- `release.yml` - on `master`, publishes release ZIP artifacts only when the
-  `package.json` version changes.
+  Biome, Rust checks, a test-only Chrome bundle, and Playwright e2e tests.
+- `release.yml` - on `v*` tag pushes, validates the tag matches
+  `package.json`, builds Chrome/Firefox/source ZIP artifacts, and publishes the
+  GitHub release.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,25 +70,8 @@ jobs:
       - name: Test Rust
         run: cargo test -p wasm-matcher
 
-      - name: Build extension packages
-        run: bun run build
-
-      - name: Stage extension artifacts
-        run: |
-          rm -rf artifacts
-          mkdir -p artifacts
-          cp .output/meow-memorizing-*-chrome.zip artifacts/
-          cp .output/meow-memorizing-*-firefox.zip artifacts/
-          cp .output/meow-memorizing-*-sources.zip artifacts/
-          ls -lh artifacts
+      - name: Build test extension bundle
+        run: bun run build:test
 
       - name: Run Playwright tests
         run: xvfb-run -a bun run test:e2e
-
-      - name: Upload extension artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: extension-zips
-          path: artifacts/*.zip
-          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - 'v*'
 
 concurrency:
   group: release-${{ github.ref }}
@@ -27,87 +27,68 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Detect version change
+      - name: Validate release tag
         id: version
         shell: bash
         run: |
           current="$(node -p "require('./package.json').version")"
-          previous="$(
-            git show HEAD^:package.json 2>/dev/null \
-              | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).version" \
-              || true
-          )"
+          expected="v$current"
 
-          if [[ "$current" == "$previous" ]]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [[ "$GITHUB_REF_NAME" != "$expected" ]]; then
+            echo "Release tag $GITHUB_REF_NAME does not match package version $expected" >&2
+            exit 1
           fi
 
-          echo "changed=true" >> "$GITHUB_OUTPUT"
           echo "version=$current" >> "$GITHUB_OUTPUT"
-          echo "tag=v$current" >> "$GITHUB_OUTPUT"
+          echo "tag=$expected" >> "$GITHUB_OUTPUT"
 
       - name: Set up Bun
-        if: steps.version.outputs.changed == 'true'
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
       - name: Set up Rust
-        if: steps.version.outputs.changed == 'true'
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
           components: rustfmt,clippy
 
       - name: Cache Rust
-        if: steps.version.outputs.changed == 'true'
         uses: Swatinem/rust-cache@v2
 
       - name: Install system linker tools
-        if: steps.version.outputs.changed == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y mold
 
       - name: Install dependencies
-        if: steps.version.outputs.changed == 'true'
         run: bun install --frozen-lockfile
 
       - name: Install wasm-bindgen CLI
-        if: steps.version.outputs.changed == 'true'
         run: cargo install wasm-bindgen-cli --version 0.2.122 --locked
 
       - name: Install Chromium
-        if: steps.version.outputs.changed == 'true'
         run: bunx playwright install --with-deps chromium
 
       - name: Check formatting and lint
-        if: steps.version.outputs.changed == 'true'
         run: bunx biome ci biome.jsonc package.json playwright.config.ts scripts/update-readme-gif.ts tests/e2e/bundleHarness.ts
 
       - name: Build WASM bindings
-        if: steps.version.outputs.changed == 'true'
         run: bun run wasm
 
       - name: Type-check
-        if: steps.version.outputs.changed == 'true'
         run: bun run compile
 
       - name: Lint Rust
-        if: steps.version.outputs.changed == 'true'
         run: bun run lint:rust
 
       - name: Test Rust
-        if: steps.version.outputs.changed == 'true'
         run: cargo test -p wasm-matcher
 
       - name: Build extension packages
-        if: steps.version.outputs.changed == 'true'
         run: bun run build
 
       - name: Stage extension artifacts
-        if: steps.version.outputs.changed == 'true'
         run: |
           rm -rf artifacts
           mkdir -p artifacts
@@ -117,23 +98,14 @@ jobs:
           ls -lh artifacts
 
       - name: Run Playwright tests
-        if: steps.version.outputs.changed == 'true'
         run: xvfb-run -a bun run test:e2e
 
       - name: Publish GitHub release
-        if: steps.version.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
         shell: bash
         run: |
-          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
-            git tag "$TAG" "$GITHUB_SHA"
-            git push \
-              "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-              "refs/tags/$TAG"
-          fi
-
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" artifacts/*.zip --clobber
           else

--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 
 > 🐈️  一个简单易用的记单词浏览器插件 ([讨论](https://github.com/yebei199/meow-memorizing/discussions))
 
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fyebei199%2Fmeow-memorizing.svg?type=small)](https://app.fossa.com/projects/git%2Bgithub.com%2Fyebei199%2Fmeow-memorizing?ref=badge_small)
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fyebei199%2Fmeow-memorizing.svg?type=shield&issueType=security)](https://app.fossa.com/projects/git%2Bgithub.com%2Fyebei199%2Fmeow-memorizing?ref=badge_shield&issueType=security)
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fyebei199%2Fmeow-memorizing.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fyebei199%2Fmeow-memorizing?ref=badge_shield&issueType=license)
 ![License](https://img.shields.io/github/license/yebei199/meow-memorizing.svg)
 
 ![ts](https://img.shields.io/badge/typescript-blue?logo=typescript&logoColor=white)
@@ -68,5 +65,3 @@ Code: (c) 2024 - Present - yebei199
 **License**: GPL-3.0-only
 
 **License Text**: [View License Text](LICENSE)
-
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fyebei199%2Fmeow-memorizing.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fyebei199%2Fmeow-memorizing?ref=badge_large)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev:firefox": "wxt -b firefox",
     "wasm": "bash scripts/build-wasm.sh && bun run scripts/inline-wasm.ts",
     "build": "mkdir -p target && rustc --edition=2021 scripts/package-extensions.rs -o target/package-extensions && target/package-extensions",
+    "build:test": "bun run wasm && bunx wxt build -b chrome",
     "build:chrome": "bun run wasm && wxt zip -b chrome && bun run src/copy.ts",
     "build:firefox": "bun run wasm && wxt zip -b firefox --sources",
     "zip": "bun run build:chrome",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,4 +22,6 @@ Build helpers for the Rust→WASM matcher.
   URL.
 
 Run the WASM steps via `bun run wasm`; the `build` scripts call them
-automatically. Regenerate the README demo with `bun run docs:gif`.
+automatically. `bun run build:test` creates only the Chrome bundle needed by
+Playwright and does not create release ZIPs. Regenerate the README demo with
+`bun run docs:gif`.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,7 +1,7 @@
 # tests/e2e
 
-Playwright end-to-end tests. Run with `bun run test:e2e` (requires a built
-extension: `bun run build`, and the wasm glue from `bun run wasm`).
+Playwright end-to-end tests. Run with `bun run build:test` first, then
+`bun run test:e2e`.
 
 Tests do **not** load the unpacked extension: recent Chrome (≥ ~137; 148 here)
 blocks `--load-extension`, and CDP `Extensions.loadUnpacked` leaves the
@@ -34,5 +34,5 @@ real matcher (a stand-in for the background worker). This runs in any Chrome.
   both timings.
 
 Browser: system Chrome (no Playwright-managed binary). Override the path with
-`PLAYWRIGHT_CHROME`. All specs need a fresh `bun run build` (they read the
-built `.output/chrome-mv3` bundle + manifest).
+`PLAYWRIGHT_CHROME`. All specs need a fresh `bun run build:test` (they read
+the built `.output/chrome-mv3` bundle + manifest).


### PR DESCRIPTION
## What changed

- Removed FOSSA badges from the README.
- Changed normal CI to build only the Chrome bundle needed for Playwright tests, without staging or uploading extension ZIP artifacts.
- Changed the release workflow to run only on `v*` tag pushes, validate the tag against `package.json`, then build and publish Chrome, Firefox, and source ZIP artifacts.

## Why

FOSSA is no longer used for this repository, and release packaging should happen only when a release tag is created.

## Validation

- `bunx biome ci biome.jsonc package.json playwright.config.ts scripts/update-readme-gif.ts tests/e2e/bundleHarness.ts`
- `bun run build:test` and confirmed no `.output/meow-memorizing-*.zip` was created
- `bun run compile`
- `bun run lint:rust`
- `cargo test -p wasm-matcher`
- `PLAYWRIGHT_CHROME=/etc/profiles/per-user/yb/bin/google-chrome bun run test:e2e`
- `bun run build` and confirmed Chrome, Firefox, and source ZIP artifacts are produced